### PR TITLE
Fix typo in title on home page

### DIFF
--- a/2020/index.html
+++ b/2020/index.html
@@ -399,7 +399,7 @@ Please reach out to the authors with any questions or if their paper is not avai
   <br> </td>
   <tr><td width=140>Session 5<br>13:00<br>13:15 (3 short)</td>
     <td>  <font color="#000000" size=2>
-    Projection Mapping Implementation: Enabling Accurate Externalization of Perception Results and Action Intent to Improve Robot Explainability <br>
+    Projection Mapping Implementation: Enabling Direct Externalization of Perception Results and Action Intent to Improve Robot Explainability <br>
     Zhao Han, Alexander Wilkinson, Jenna Parrillo, Jordan Allspaw, and Holly Yanco
     <br><br>
     Modeling Human Temporal Uncertainty in Human-Agent Teams <br>


### PR DESCRIPTION
Accurate -> Direct

(Not sure when this was changed)